### PR TITLE
Update Stack to lts-7.24

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-7.0
+resolver: lts-7.24
 nix:
   enable: false
   packages: [zlib]


### PR DESCRIPTION
The cabal file for the project depends on conduit version >= 1.2.8, but Stack lts-7.0 only has version 1.2.7. Update the lts version to the current latest 7.x to satisfy the dependency.