### PR TITLE
Add conduits to decode/encode to Network.IRC.Message

### DIFF
--- a/Network/IRC/Conduit/Internal.hs
+++ b/Network/IRC/Conduit/Internal.hs
@@ -165,6 +165,9 @@ data Message a = Privmsg (Target a) (Either CTCPByteString a)
 fromByteString :: ByteString -> Either ByteString IrcEvent
 fromByteString bs = maybe (Left bs) Right $ uncurry (Event bs) <$> attemptDecode bs
 
+fromByteStringMessage :: ByteString -> Either ByteString I.Message
+fromByteStringMessage bs = maybe (Left bs) Right (I.decode bs)
+
 -- |Attempt to decode a ByteString into a message, returning a Nothing
 -- if either the source or the message can't be determined.
 attemptDecode :: ByteString -> Maybe (IrcSource, IrcMessage)


### PR DESCRIPTION
The existing implementation attempts to decode to an `irc-conduit` data type. The decode sometimes fails even though the underlying IRC library is able to decode the message.

This PR adds conduits to encode and decode to the message data type from `Network.IRC` directly without attempting to convert to the `irc-conduit` data type.