### PR TITLE
Use haskell/actions/setup instead of mstksg/setup-stack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: 'https://github.com/mstksg/setup-stack/issues/13'
-        run: 'echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV'
       - uses: actions/checkout@v2
-      - uses: mstksg/setup-stack@v2
+      - uses: haskell/actions/setup@v1
+        with:
+          enable-stack: true
       - name: Setup
         run: |
           stack --no-terminal install stylish-haskell hlint
@@ -22,10 +22,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: 'https://github.com/mstksg/setup-stack/issues/13'
-        run: 'echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV'
       - uses: actions/checkout@v2
-      - uses: mstksg/setup-stack@v2
+      - uses: haskell/actions/setup@v1
+        with:
+          enable-stack: true
       - name: Build
         run: |
           stack --no-terminal build


### PR DESCRIPTION
setup-stack hasn't had a commit in over a year and needs an env var
setting to work around some default github-actions security, so it
seems to be abandonware.