### PR TITLE
Use `--install-ghc` in concourse script

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -27,7 +27,7 @@ x-task-build-and-test: &task-build-and-test
           $stack init --resolver="$resolver" --force
         fi
 
-        $stack setup
+        $stack setup --install-ghc
         $stack build
 
 ###############################################################################
@@ -117,5 +117,5 @@ jobs:
                     exit 0
                   fi
 
-                  stack --no-terminal setup
+                  stack --no-terminal setup --install-ghc
                   echo n | stack --no-terminal upload .


### PR DESCRIPTION
Looks like the default is to not install GHC now:

    + stack --no-terminal setup
    The --no-install-ghc flag is inconsistent with 'stack setup'. No
    action taken.