### PR TITLE
Allow text 2.0 and tls 1.6

### DIFF
--- a/irc-conduit.cabal
+++ b/irc-conduit.cabal
@@ -89,9 +89,9 @@ library
                      , irc-ctcp            >=0.1.1 && <0.2
                      , network-conduit-tls >=1.1   && <1.4
                      , profunctors         >=5     && <6
-                     , text                >=1.0   && <1.3
+                     , text                >=1.0   && <2.1
                      , time                >=1.4   && <2
-                     , tls                 >=1.3   && <1.6
+                     , tls                 >=1.3   && <1.7
                      , transformers        >=0.3   && <0.6
                      , x509-validation     >=1.6   && <1.7
  


### PR DESCRIPTION
Fixes half of https://github.com/barrucadu/irc-conduit/issues/54